### PR TITLE
Dependent Recipes, Bugfixes, and slight refactor

### DIFF
--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="showAlert" :class="[alertColor]" class="flex flex-row font-medium text-white p-2 shadow-sm rounded-lg justify-between space-x-3 mx-2 mb-1">
+  <div v-if="showAlert" :class="[alertColor]" class="flex flex-row font-medium text-white p-2 shadow-sm rounded-md justify-between space-x-3 mb-1">
     <div class="flex h-7 w-7 rounded-full justify-center items-center">
       <svg v-if="alertType == 'danger'" class="h-7 w-7" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />

--- a/src/components/publish/recipe/DependentRecipes.vue
+++ b/src/components/publish/recipe/DependentRecipes.vue
@@ -1,0 +1,153 @@
+<template>
+    <template v-for="parentRecipe in recipe.parentRecipes" :key="parentRecipe.id">
+      <router-link :to="{ name: 'RecipeShow', params: { id: parentRecipe.id }}">
+        <div @click="navigate" class="flex flex-col text-sm rounded-md bg-gray-50 text-gray-400 hover:bg-rose-300 hover:text-white font-serif px-3 py-1 mb-1 justify-between">
+          <div class="flex justify-center">
+            <p>Required to make:  
+              <span class="text-center font-bold">{{parentRecipe.name}}</span>
+            </p>
+          </div>
+        </div>
+      </router-link>
+    </template>
+  <div class="flex flex-col">
+    <div class="flex mb-3">
+      <p class="text-sm text-gray-400">Great for more complex recipes. A good exmaple is if this was a Lasagna Recipe, 
+        Dependent Recipes would be a Bolognese Sauce, Fresh Pasta, and Bachemal Sauce. 
+      </p>
+    </div>
+
+    <div v-for="dependentRecipe in recipe.dependentRecipes" :key="dependentRecipe.id" class="flex flex-row rounded-sm shadow-sm bg-rose-500 text-white px-3 py-1 mb-1 justify-between">
+      <div class="flex">
+        <span class="font-medium w-3 text-right">{{dependentRecipe.qty}}</span>
+        <span v-if="dependentRecipe.qty > 1" class="text-rose-100 mx-2">batches of</span>
+        <span v-else class="text-rose-100 mx-2 mr-6">batch of</span>  
+        <span class="font-medium">{{dependentRecipe.name}}</span>
+      </div>
+      <div @click="removeDependentRecipe(dependentRecipe)" class="flex">
+        <svg class="h-6 w-6 hover:text-rose-200" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+      </div>
+    </div>
+    <Alert v-for="(error, index) in errors" :key="index" alertType="danger" :message="error"/>
+    <div class="relative">
+      <div class="flex mt-2 space-x-1">
+        <input @keyup="getSuggestions(recipeName)" v-model="recipeName" class="w-8/12 text-gray-500 h-8 border-b border-gray-200 focus:outline-none focus:ring px-2" type="text" placeholder="recipe name...">
+        <input v-model="recipeQty" class="w-3/12 text-gray-500 h-8 border-b border-gray-200 focus:outline-none focus:ring px-2 text-center" type="text" placeholder="batch qty">
+        <button @click="addDependentRecipe()" class="w-1/12  text-rose-500 rounded-md pl-2 hover:text-rose-600">
+          <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+        </button>
+      </div>
+      <div v-if="displaySuggestions" class="flex flex-row w-8/12 bg-red-200 rounded-b-md shadow-lg absolute top-10 overflow-auto h-auto max-h-32">
+        <ul class="rounded-b-md w-full">
+          <li 
+            v-for="suggestion in suggestions" :key="suggestion.id"
+            @click="selectSuggestion(suggestion)" 
+            class="bg-white border-t border-gray-200 pl-2 py-1 text-rose-500 font-medium hover:bg-rose-500 hover:text-white select-none" 
+          >
+            {{suggestion.name}}
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+  import { mapGetters } from "vuex";
+  import { RecipeService } from "@/services/apiService.js"
+  import Alert from "@/components/Alert.vue"
+
+  export default {
+    name: "DependentRecipes",
+    components :{
+      Alert,
+    },
+    data() {
+      return {
+        recipeName: "",
+        recipeQty: "",
+        recipeId: 0,
+        suggestions: [],
+        errors: []
+      }
+    },
+    methods: {
+      getSuggestions(input){
+
+        /**
+         * Help reduce DB calls by only searching every 
+         * other key press after 2
+         */
+        if (input.length > 2 && input.length % 2){
+          RecipeService.getRecipesLike(input)
+          .then(response => {
+            console.log(response.data)
+            if (response.data.success) {
+              this.suggestions = response.data.data
+              console.log(this.suggestions)
+            }
+          })
+          .catch(error => {
+            console.log(error)
+          })
+        }
+        
+      },
+      selectSuggestion(suggestion){
+        this.recipeName = suggestion.name
+        this.recipeId = suggestion.id
+        this.suggestions = []
+      },
+      addDependentRecipe(){
+
+        for (const dependent of this.recipe.dependentRecipes){
+          if (this.recipeName === dependent.name){
+            this.errors.push("That recipe is already listed as a dependency.")
+            return false
+          }
+        }
+
+        if (this.recipeQty < 1){
+          this.errors.push("You must specify how many batches of this recipe are needed.")
+          return false
+        }
+
+        if (this.recipeId == this.$route.params.id){
+          this.errors.push("A recipe cannot be dependent upon itself.")
+          return false
+        }
+
+        const dependency = {
+          id: this.recipeId,
+          name: this.recipeName,
+          qty: this.recipeQty
+        }
+        this.$store.dispatch('addDependentRecipe', dependency)
+        this.recipeId = 0
+        this.recipeName = ""
+        this.recipeQty = ""
+        console.log(this.recipe)
+      },
+      removeDependentRecipe(dependency){
+        this.$store.dispatch('removeDependentRecipe', dependency)
+      }
+    },
+    computed: {
+      ...mapGetters(["recipe"]),
+      displaySuggestions(){
+        if (this.suggestions.length > 0) {
+          return true
+        }
+        return false
+      }
+    },
+  }
+</script>
+
+<style lang="postcss" scoped>
+
+</style>

--- a/src/components/publish/recipe/index.js
+++ b/src/components/publish/recipe/index.js
@@ -2,6 +2,7 @@ import RecipeTitleBar from "@/components/publish/recipe/RecipeTitleBar.vue"
 import RecipeToolBar from "@/components/publish/recipe/RecipeToolBar.vue"
 import RecipePhoto from "@/components/publish/recipe/RecipePhoto.vue"
 import RecipeDescription from "@/components/publish/recipe/RecipeDescription.vue"
+import DependentRecipes from "@/components/publish/recipe/DependentRecipes.vue"
 
 import IngredientsToolBar from "@/components/publish/recipe/IngredientsToolBar.vue"
 import IngredientGroup from "@/components/publish/recipe/IngredientGroup.vue"
@@ -11,6 +12,7 @@ export {
     RecipeToolBar,
     RecipePhoto,
     RecipeDescription,
+    DependentRecipes,
     IngredientsToolBar,
     IngredientGroup
 }

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -47,6 +47,9 @@ export const ImageService = {
 }
 
 export const RecipeService = {
+    getRecipesLike(searchString){
+        return axios.get('/publish/recipes?name='+searchString)
+    },
     getRecipes(){
         return axios.get('/publish/recipes')
     },
@@ -56,21 +59,31 @@ export const RecipeService = {
     createRecipe(recipe){      
       trimEmpty(recipe)
       console.log(recipe)
-      return axios.post('/publish/recipes', recipe)
+      
+      return axios.post('/publish/recipes', {recipe})
     },
     updateRecipe(recipe){
         trimEmpty(recipe)
         console.log(recipe)
-        return axios.put('/publish/recipes/' + recipe.id, recipe)
+        return axios.put('/publish/recipes/' + recipe.id, {recipe})
     }
 }
 
 export const AuthService = {
     createUser({username, displayName, email, password}){
-        return axios.post('/auth/register', {username, displayName, email, password})
+        const payload = {
+          registration: {
+            username, 
+            displayName, 
+            email, 
+            password
+          }
+        }
+
+        return axios.post('/auth/register', payload)
     },
     login({email, password}){
-        return axios.post('/auth/login', {email, password})
+        return axios.post('/auth/login', {login: {email, password}})
     },
     getAccount(){
       return axios.get('/auth/account')

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -38,6 +38,7 @@ export default createStore({
         ({ data }) => {
           if (data.success){
             commit('SET_USER_DATA', data.data.accessToken)
+            return data
           } else {
             //return errors back to component
             return data

--- a/src/store/recipe.module.js
+++ b/src/store/recipe.module.js
@@ -6,6 +6,9 @@ const getDefaultState = () => {
       name: "",
       image: "",
       description: "",
+      dependentRecipes: [
+
+      ],
       ingredientGroups: [
         {
           groupName: '',
@@ -77,6 +80,12 @@ export const actions = {
   },
   addIngredientGroup({ commit }){
     commit('ADD_INGREDIENT_GROUP')
+  },
+  addDependentRecipe({ commit }, payload){
+    commit('ADD_DEPENDENT_RECIPE', payload)
+  },
+  removeDependentRecipe({ commit }, payload){
+    commit('REMOVE_DEPENDENT_RECIPE', payload)
   }
 }
 
@@ -154,7 +163,14 @@ export const mutations= {
       ]
     }
     state.recipe.ingredientGroups.push(newGroup)
-  },  
+  },
+  ADD_DEPENDENT_RECIPE(state, recipe){
+    state.recipe.dependentRecipes.push(recipe)
+  },
+  REMOVE_DEPENDENT_RECIPE(state, recipe){
+    const index = state.recipe.dependentRecipes.indexOf(recipe)
+    state.recipe.dependentRecipes.splice(index, 1)
+  }   
 }
 
 const getters = {

--- a/src/views/Signup.vue
+++ b/src/views/Signup.vue
@@ -33,7 +33,7 @@
         </form>
       </div>
 
-      <div v-if="passwordsMatch" class="text-center">
+      <div v-if="passwordMismatch" class="text-center">
         <p class="text-red-500">Password mismatch.</p>
       </div>
       <div v-for="error in errors"  :key="error" class="text-center">
@@ -55,16 +55,16 @@ export default {
       password: '',
       passwordConfirm: '',
       errors: [],
-      passwordsMatch: null,
+      passwordMismatch: null,
     }
   },
   methods: {
     register() {
 
-      if (this.password == this.passwordConfirm) {
-        this.passwordsMatch = true
+      if (this.password != this.passwordConfirm) {
+        this.passwordMismatch = true
       } else {
-        this.passwordsMatch = false
+        this.passwordMismatch = false
       }
 
       this.$store.dispatch('register', {
@@ -74,7 +74,7 @@ export default {
         password: this.password,
       })
       .then( response => {
-        
+        console.log(response)
         if (response.success) {
           this.$router.push({ name: 'Home'})
         } else {

--- a/src/views/publish/RecipeEdit.vue
+++ b/src/views/publish/RecipeEdit.vue
@@ -34,6 +34,20 @@
       
       <div class="flex flex-row h-screen justify-end mx-2 mb-2 shadow rounded-lg">
         <div class="flex flex-col overflow-y-scroll bg-white w-2/3 p-5 rounded-l-lg">
+        <template v-for="parentRecipe in recipe.parentRecipes" :key="parentRecipe.id">
+          <router-link :to="{ name: 'RecipeShow', params: { id: parentRecipe.id }}">
+            <div @click="navigate" class="flex flex-col text-sm rounded-md bg-light-blue-400 text-white hover:bg-light-blue-500 hover:text-white px-3 py-1 mb-1 justify-between">
+              <div class="flex justify-center">
+                <svg class="h6 w-6 mr-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <p>Required to make:  
+                  <span class="text-center font-bold">{{parentRecipe.name}}</span>
+                </p>
+              </div>
+            </div>
+          </router-link>
+        </template>
 
           <label for="description" class="this-label">Photo</label>
           <ImageSelector 
@@ -50,8 +64,12 @@
 
           <label for="description" class="this-label">Description</label>
           <RecipeDescription v-model="recipe.description"/>
-          <IngredientsToolBar/>
 
+
+          <label for="description" class="this-label">Dependent Recipes</label>
+          <DependentRecipes/>
+
+          <IngredientsToolBar/>
           <div class="flex flex-col">
             <template
             v-for="(group, index) in recipe.ingredientGroups" 
@@ -140,6 +158,7 @@
   import Alert from "@/components/Alert.vue"
   import {
     RecipeDescription,
+    DependentRecipes,
     IngredientsToolBar,
     IngredientGroup
   } from "@/components/publish/recipe"
@@ -158,6 +177,7 @@
     components: {
       Alert,
       RecipeDescription,
+      DependentRecipes,
       IngredientsToolBar,
       IngredientGroup,
       StepTemplates,

--- a/src/views/publish/RecipeList.vue
+++ b/src/views/publish/RecipeList.vue
@@ -16,23 +16,32 @@
           </router-link>
         </div>
 
-        <table class="table-fixed shadow-md rounded-md mt-3">
-          <thead class=" text-rose-500 bg-white">
-            <th class=" rounded-tl-md font-normal py-2">Name</th>
-            <th class=" w-16 font-normal">State</th>
-            <th class=" w-1/3 font-normal">Tags</th>
-            <th class=" rounded-tr-md w-12 font-normal">
-            </th>
-          </thead>
-          <tbody class="bg-white">
-            <RecipeListItem 
-              v-for="(recipe, index) in recipes" 
-              :key="index" 
-              :recipeName="recipe.name"
-              :recipeId="recipe.id"
-            />
-          </tbody>
-        </table>
+        <template v-if="recipes">
+          <table class="table-fixed shadow-md rounded-md mt-3">
+            <thead class=" text-rose-500 bg-white">
+              <th class=" rounded-tl-md font-normal py-2">Name</th>
+              <th class=" w-16 font-normal">State</th>
+              <th class=" w-1/3 font-normal">Tags</th>
+              <th class=" rounded-tr-md w-12 font-normal">
+              </th>
+            </thead>
+            <tbody class="bg-white">
+              <RecipeListItem 
+                v-for="(recipe, index) in recipes" 
+                :key="index" 
+                :recipeName="recipe.name"
+                :recipeId="recipe.id"
+              />
+            </tbody>
+          </table>
+        </template>
+        <template v-else>
+          <div class="flex bg-white w-2/5 mx-auto mt-10 rounded-md p-5 text-rose-500">
+            <p>
+              You haven't written any recipes yet.  Click the <span class="text-xl font-bold">+</span> to create your first one.
+            </p>
+          </div>
+        </template>
 
     </div>
 </template>

--- a/src/views/publish/RecipeShow.vue
+++ b/src/views/publish/RecipeShow.vue
@@ -13,28 +13,41 @@
         
         <div class="flex flex-col bg-gray-50 lg:flex-row h-full pt-4 shadow rounded-lg">
             <div class="flex flex-col lg:w-2/6 px-10">
-                <h2 class="text-xl uppercase mb-4 px-10">Ingredients</h2>
+                <h2 class="text-xl block text-center uppercase mb-4 px-10">Ingredients</h2>
+                <h3 v-if="hasDependencies" class="font-medium block text-center mb-2">Requires</h3>
+                <template v-for="dependentRecipe in recipe.dependentRecipes" :key="dependentRecipe.id">
+                  <router-link :to="{ name: 'RecipeShow', params: { id: dependentRecipe.id }}">
+                    <div @click="navigate" class="flex flex-col text-sm rounded-md shadow-sm bg-rose-500 text-white hover:bg-rose-600 font-serif px-3 py-1 mb-1 justify-between">
+                      <div class="flex justify-center">
+                        <span class="font-medium w-3 text-right">{{dependentRecipe.qty}}</span>
+                        <span v-if="dependentRecipe.qty > 1" class="mx-2">batches of</span>
+                        <span v-else class="mx-2 mr-6">batch of</span>  
+                      </div>
+                      <div class="flex justify-center">
+                        <span class="text-center font-medium">{{dependentRecipe.name}}</span>
+                      </div>
+                    </div>
+                  </router-link>
+                </template>
+                <h3 v-if="hasDependencies" class="font-medium block text-center mt-2">This Recipe</h3>
                 <template v-for="group in recipe.ingredientGroups" :key="group">
                     <h3 class="font-medium">{{group.groupName}}</h3>
                     <ul class="font-serif mb-3">
                         <li 
                         class="mt-2 step-focus"
                         tabindex="0"
-                        v-for="item in group.ingredients" :key="item">
+                        v-for="item in group.ingredients" :key="item"
+                        >
 
-                        <div class="flex flex-row">
-                          <div class=" flex w-12  pr-2">
-                            <p class="block w-full text-right">{{item.qty}}</p>
+                          <div class="flex flex-row">
+                            <div class=" flex w-12  pr-2">
+                              <p class="block w-full text-right">{{item.qty}}</p>
+                            </div>
+                            <div class="flex">
+                              {{item.unit}} {{item.name}}
+                            </div>
                           </div>
-                          <div class="flex">
-                            {{item.unit}} {{item.name}}
-                          </div>
-                        </div>
 
-
-                        
-                        
-                        
                         </li>
                     </ul>
                 </template>
@@ -108,6 +121,18 @@
 
                 </div>
               </template>
+
+                <template v-for="parentRecipe in recipe.parentRecipes" :key="parentRecipe.id">
+                  <router-link :to="{ name: 'RecipeShow', params: { id: parentRecipe.id }}">
+                    <div @click="navigate" class="flex flex-col text-sm rounded-md bg-gray-50 text-gray-400 hover:bg-rose-300 hover:text-white font-serif px-3 py-1 mb-1 justify-between">
+                      <div class="flex justify-center">
+                        <p>Required to make:  
+                          <span class="text-center font-bold">{{parentRecipe.name}}</span>
+                        </p>
+                      </div>
+                    </div>
+                  </router-link>
+                </template>
           </div>
         </div>  
   </div>  
@@ -118,6 +143,13 @@ import { mapGetters } from "vuex";
 import store from "@/store"
 export default {
   beforeRouteEnter(to, from, next) {
+    Promise.all([
+        store.dispatch('getRecipe', to.params.id),
+    ]).then(() => {
+        next();
+    });
+  },
+  beforeRouteUpdate(to, from, next) {
     Promise.all([
         store.dispatch('getRecipe', to.params.id),
     ]).then(() => {
@@ -135,7 +167,13 @@ export default {
           stepNum++
         }
       })
-    return stepMap
+      return stepMap
+    },
+    hasDependencies(){
+      if (this.recipe.dependentRecipes.length > 0) {
+        return true
+      }
+      return false 
     }
   },
 }


### PR DESCRIPTION
Polishing up dependent recipes.  to Ensure
- user can't add recipe twice
- recipe can't add itself as dependent
- recipe must have a batch qty when added
- dependents show up on a recipe view both dependents and parent recipes

fixed some bugs with login and register forms
refactored the JSON send object to include top-level-key compatible with backend go structs. 